### PR TITLE
fix: missed NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY env var

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,7 +6,9 @@ SECRET=RAMDOM_STRING
 SMTP_SERVER=smtp://localhost:1025?ignoreTLS=true
 SMTP_FROM=dev@sendgrid.softlayer.com
 
-# STRIPE
+# STRIPE 
+# Update these with credentials from https://dashboard.stripe.com/apikeys
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 


### PR DESCRIPTION
`yarn dev` failed locally due to above env var not defined.
Following https://github.com/vercel/nextjs-subscription-payments/blob/main/.env.local.example.